### PR TITLE
Added an option to Invert the overlay image.

### DIFF
--- a/chrome/locale/en-US/popup-panel.properties
+++ b/chrome/locale/en-US/popup-panel.properties
@@ -7,7 +7,7 @@ pixelPerfect.label.x=X
 pixelPerfect.label.y=Y
 pixelPerfect.label.scale=Scale
 pixelPerfect.label.lock=Lock
-pixelPerfect.label.inverse=Inverse
+pixelPerfect.label.invert=Invert
 pixelPerfect.label.addLayer=Add Layer
 
 # LOCALIZATION NOTE (pixelPerfect.help.desc): description displayed

--- a/chrome/locale/en-US/popup-panel.properties
+++ b/chrome/locale/en-US/popup-panel.properties
@@ -7,6 +7,7 @@ pixelPerfect.label.x=X
 pixelPerfect.label.y=Y
 pixelPerfect.label.scale=Scale
 pixelPerfect.label.lock=Lock
+pixelPerfect.label.inverse=Inverse
 pixelPerfect.label.addLayer=Add Layer
 
 # LOCALIZATION NOTE (pixelPerfect.help.desc): description displayed

--- a/chrome/skin/classic/shared/ua.css
+++ b/chrome/skin/classic/shared/ua.css
@@ -19,6 +19,6 @@ div:-moz-native-anonymous.moz-custom-content-container {
   pointer-events: none;
 }
 
-.pixelperfect-layer-box[inverse] img {
+.pixelperfect-layer-box[invert] img {
 	filter: invert(100%);
 }

--- a/chrome/skin/classic/shared/ua.css
+++ b/chrome/skin/classic/shared/ua.css
@@ -18,3 +18,7 @@ div:-moz-native-anonymous.moz-custom-content-container {
   cursor: default;
   pointer-events: none;
 }
+
+.pixelperfect-layer-box[inverse] img {
+	filter: invert(100%);
+}

--- a/data/layer-form.js
+++ b/data/layer-form.js
@@ -104,13 +104,13 @@ var LayerForm = React.createClass({
         TR({},
           TD({className: "right"},
             LABEL({className: "pixel-perfect-label",
-              htmlFor: "pixel-perfect-inverse"},
-              Locale.$STR("pixelPerfect.label.inverse") + ":")
+              htmlFor: "pixel-perfect-invert"},
+              Locale.$STR("pixelPerfect.label.invert") + ":")
           ),
           TD({colSpan: 2},
-            INPUT({type: "checkbox", checked: layer.inverse,
-              id: "pixel-perfect-inverse",
-              onChange: this.onChange.bind(this, "inverse", "boolean")})
+            INPUT({type: "checkbox", checked: layer.invert,
+              id: "pixel-perfect-invert",
+              onChange: this.onChange.bind(this, "invert", "boolean")})
           )
         ),
         TR({},

--- a/data/layer-form.js
+++ b/data/layer-form.js
@@ -34,7 +34,7 @@ var LayerForm = React.createClass({
         TR({},
           TD({className: "right"},
             LABEL({className: "pixel-perfect-label",
-              htmlFor: "pixel-perfect-opacity"}, 
+              htmlFor: "pixel-perfect-opacity"},
               Locale.$STR("pixelPerfect.label.opacity") + ":"
             )
           ),
@@ -52,8 +52,8 @@ var LayerForm = React.createClass({
         TR({},
           TD({className: "right"},
             LABEL({className: "pixel-perfect-label",
-              htmlFor: "pixel-perfect-x"}, 
-              Locale.$STR("pixelPerfect.label.x") + ":") 
+              htmlFor: "pixel-perfect-x"},
+              Locale.$STR("pixelPerfect.label.x") + ":")
           ),
           TD({className: "positionCell", colSpan: 2},
             TABLE({className: "position"},
@@ -78,7 +78,7 @@ var LayerForm = React.createClass({
           )
         ),
         TR({},
-          TD({className: "right"}, 
+          TD({className: "right"},
             LABEL({className: "pixel-perfect-label",
               htmlFor: "pixel-perfect-scale"},
               Locale.$STR("pixelPerfect.label.scale") + ":")
@@ -90,7 +90,7 @@ var LayerForm = React.createClass({
           )
         ),
         TR({},
-          TD({className: "right"}, 
+          TD({className: "right"},
             LABEL({className: "pixel-perfect-label",
               htmlFor: "pixel-perfect-lock"},
               Locale.$STR("pixelPerfect.label.lock") + ":")
@@ -99,6 +99,18 @@ var LayerForm = React.createClass({
             INPUT({type: "checkbox", checked: layer.lock,
               id: "pixel-perfect-lock",
               onChange: this.onChange.bind(this, "lock", "boolean")})
+          )
+        ),
+        TR({},
+          TD({className: "right"},
+            LABEL({className: "pixel-perfect-label",
+              htmlFor: "pixel-perfect-inverse"},
+              Locale.$STR("pixelPerfect.label.inverse") + ":")
+          ),
+          TD({colSpan: 2},
+            INPUT({type: "checkbox", checked: layer.inverse,
+              id: "pixel-perfect-inverse",
+              onChange: this.onChange.bind(this, "inverse", "boolean")})
           )
         ),
         TR({},

--- a/lib/pixel-perfect-actor.js
+++ b/lib/pixel-perfect-actor.js
@@ -364,10 +364,10 @@ var PixelPerfectActor = ActorClass(
       content.removeAttributeForElement("box" + layer.id, "lock");
     }
 
-    if (layer.inverse) {
-      content.setAttributeForElement("box" + layer.id, "inverse", "true");
+    if (layer.invert) {
+      content.setAttributeForElement("box" + layer.id, "invert", "true");
     } else {
-      content.removeAttributeForElement("box" + layer.id, "inverse");
+      content.removeAttributeForElement("box" + layer.id, "invert");
     }
 
     // Update image styles

--- a/lib/pixel-perfect-actor.js
+++ b/lib/pixel-perfect-actor.js
@@ -364,6 +364,12 @@ var PixelPerfectActor = ActorClass(
       content.removeAttributeForElement("box" + layer.id, "lock");
     }
 
+    if (layer.inverse) {
+      content.setAttributeForElement("box" + layer.id, "inverse", "true");
+    } else {
+      content.removeAttributeForElement("box" + layer.id, "inverse");
+    }
+
     // Update image styles
     let imageStyle = "";
     imageStyle += "opacity: " + (parseInt(layer.opacity, 10) / 100) + ";";


### PR DESCRIPTION
Inversing the image shows the differences as color flashes. Areas that match perfectly will remain gray.

I've attached a test image of the getfirebug homepage as well as a sample screenshot where I've moved the logo over a few pixels to illustrate what happens when there is a difference between the page and the overlay :)

![getfirebug](https://cloud.githubusercontent.com/assets/788414/6520020/1c71fda4-c371-11e4-9fec-b18a24388c96.png)
![getfirebug_inverse_applied_poc](https://cloud.githubusercontent.com/assets/788414/6520022/22968e3e-c371-11e4-9ee0-f19bae65e551.png)
